### PR TITLE
ascii quotation marks in README to avoid encoding errors on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Besides `textgrids.version`, which contains the module version number as string,
 
 `diacritics` is a `dict` of all diacritics in Praat notation (as keys) and their Unicode counterparts (as values).
 
-`inline_diacritics` and `index_diacritics` are subsets of `diacritics`. The former are semantically diacritics but appear as inline symbols, the latter are the “true” diacritics (i.e., under- or overstrikes) that need special handling when transcoding.
+`inline_diacritics` and `index_diacritics` are subsets of `diacritics`. The former are semantically diacritics but appear as inline symbols, the latter are the "true" diacritics (i.e., under- or overstrikes) that need special handling when transcoding.
 
 ### 0.4. TEXT_LONG, TEXT_SHORT, BINARY
 


### PR DESCRIPTION
This solves the following error when installing from pip on (a certain) Windows 10 + Miniconda3 setup

```
      File "...\setup.py", line 39, in <module>
        long_description = readme.read()
      File "...\miniconda3\lib\encodings\cp1252.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 3159: character maps to <undefined>
```