### PR TITLE
add encoding utf-8 to setup in windows (For issue#3)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@
 
 import setuptools
 
-with open('README.md', 'r') as readme:
+with open('README.md', 'r',encoding='utf-8') as readme:
     long_description = readme.read()
 
 setuptools.setup(name='praat-textgrids',


### PR DESCRIPTION
Dear author,

 For open issue#3
I had the same issue in windows:
I solved by setting encoding="utf-8" in the setup.py

Clone the repo: git clone https://github.com/Legisign/Praat-textgrids.git
Change line 38 in setup.py : open('README.md', 'r') as readme: to with open('README.md', 'r',encoding='utf-8') as readme:
Run python setup.py install

Request to merge!

Thanks
Maulik