### PR TITLE
Two new features: Moving textgrids in time and creating & exporting tiers from lists of dicts

### DIFF
--- a/textgrids/__init__.py
+++ b/textgrids/__init__.py
@@ -131,9 +131,10 @@ class Tier(list):
         # Concatenate only tiers of the same type
         if self.is_point_tier != tier.is_point_tier:
             raise TypeError('tier types differ')
-        # Sanity check
+        # Do not add a tier at the end which begins before this one ends.
         if self.xmax > tier.xmin:
-            raise ValueError('time values do not match')
+            raise ValueError('trying to extend a tier with one that begins before this tier ends: {max} > {min}', 
+                self.xmax, tier.xmin)
         return Tier(super().__add__(tier))
 
     def merge(self, first=0, last=-1):

--- a/textgrids/__init__.py
+++ b/textgrids/__init__.py
@@ -456,6 +456,30 @@ class TextGrid(OrderedDict):
             self.xmax = tier.xmax
 
 
+    def interval_tier_to_array(self, tier_name):
+        """
+        Return the tier with tier_name as an array.
+
+        The array will contain dicts with the fields/keys label (string),
+        begin and end (float) for each interval. The dicts will be in 
+        time order from first to last.
+
+        If no Tier with the given name exists, a KeyError will be 
+        raised.
+        """
+        tier = self[tier_name]
+        table = []
+        for interval in tier:
+            element = {
+                'label': interval.text,
+                'xmin': interval.xmin,
+                'xmax': interval.xmax
+            }
+            table.append(element)
+        
+        return table
+
+
     def tier_from_csv(self, tier_name, filename):
         '''Import CSV file to an interval or point tier.
 

--- a/textgrids/__init__.py
+++ b/textgrids/__init__.py
@@ -435,6 +435,24 @@ class TextGrid(OrderedDict):
             data = infile.read()
         self.parse(data)
 
+    def interval_tier_from_array(self, tier_name, array):
+        """
+        Create a new interval tier from an array presentation.
+
+        The array should contain dicts with the fields/keys label (string),
+        begin and end (float) for each element. Other keys will be ignored.
+
+        tier_name is the name of the new tier. 
+        array is an array of interval dicts:
+            {'label': label, 'begin': time value, 'end': time_value}
+        """
+        tier = Tier()
+        for i, element in enumerate(array):
+            elem = Interval(element['label'], element['begin'], element['end'])
+            tier.append(elem)
+        self[tier_name] = tier
+
+
     def tier_from_csv(self, tier_name, filename):
         '''Import CSV file to an interval or point tier.
 

--- a/textgrids/__init__.py
+++ b/textgrids/__init__.py
@@ -451,6 +451,8 @@ class TextGrid(OrderedDict):
             elem = Interval(element['label'], element['begin'], element['end'])
             tier.append(elem)
         self[tier_name] = tier
+        if tier.xmax > self.xmax:
+            self.xmax = tier.xmax
 
 
     def tier_from_csv(self, tier_name, filename):

--- a/textgrids/__init__.py
+++ b/textgrids/__init__.py
@@ -133,7 +133,7 @@ class Tier(list):
             raise TypeError('tier types differ')
         # Do not add a tier at the end which begins before this one ends.
         if self.xmax > tier.xmin:
-            raise ValueError('trying to extend a tier with one that begins before this tier ends: {max} > {min}', 
+            raise ValueError('Cannot extend a tier with one that begins before this tier ends: {max} > {min}', 
                 self.xmax, tier.xmin)
         return Tier(super().__add__(tier))
 

--- a/textgrids/__init__.py
+++ b/textgrids/__init__.py
@@ -174,7 +174,7 @@ class Tier(list):
                                         i.xmin,
                                         i.xmax) for i in self]
 
-    def move_t0(self, offset):
+    def offset_time(self, offset):
         """Move all timestamps in this Tier, including xmin and xmax, by offset."""
         self.xmin += offset
         self.xmax += offset

--- a/textgrids/__init__.py
+++ b/textgrids/__init__.py
@@ -447,9 +447,10 @@ class TextGrid(OrderedDict):
             {'label': label, 'begin': time value, 'end': time_value}
         """
         tier = Tier()
-        for i, element in enumerate(array):
+        for element in array:
             elem = Interval(element['label'], element['begin'], element['end'])
             tier.append(elem)
+            tier.xmax = element['end']
         self[tier_name] = tier
         if tier.xmax > self.xmax:
             self.xmax = tier.xmax

--- a/textgrids/__init__.py
+++ b/textgrids/__init__.py
@@ -106,7 +106,7 @@ class Interval(object):
         step = self.dur / num
         return [self.xmin + (step * i) for i in range(num + 1)]
 
-    def move_t0(self, offset):
+    def offset_time(self, offset):
         """Move xmin and xmax by offset."""
         self.xmin += offset
         self.xmax += offset
@@ -184,7 +184,7 @@ class Tier(list):
                 point.xpos += offset
         else:
             for interval in self:
-                interval.move_t0(offset)
+                interval.offset_time(offset)
 
     @property
     def tier_type(self):
@@ -546,11 +546,11 @@ class TextGrid(OrderedDict):
         with open(filename, 'w' if fmt != BINARY else 'wb') as outfile:
             outfile.write(self.format(fmt))
 
-    def move_t0(self, offset):
+    def offset_time(self, offset):
         """Move all boundaries in this TextGrid, including xmin and xmax, by offset."""
         self.xmin += offset
         self.xmax += offset
 
         tiers = self.keys()
         for tier in tiers:
-            self[tier].move_t0(offset)
+            self[tier].offset_time(offset)


### PR DESCRIPTION
The features are useful for example in automatically generating textgrids and in chopping up large grids to shorter ones.

The moving feature simply moves the whole textgrid. 
The creating of tiers from lists of dicts and exporting them as such assumes all dicts in the list have the documented keys. In creation any extra keys are ignored.