### PR TITLE
Fix IntervalTiers all indexed as [1] in textgrids.TextGrid.format output

### DIFF
--- a/textgrids/__init__.py
+++ b/textgrids/__init__.py
@@ -271,6 +271,7 @@ class TextGrid(OrderedDict):
                                                 elem.xmin,
                                                 elem.xmax,
                                                 elem.text)
+            tier_count += 1
         return out
 
     def _format_short(self):


### PR DESCRIPTION
Hi,

Thanks for the module. During use I noticed that `TextGrid._format_long()` is missing a counter increment for IntervalTier items. This pull request adds the increment.

Leo