### PR TITLE
Fix parsing text starting with a newline

### DIFF
--- a/textgrids/__init__.py
+++ b/textgrids/__init__.py
@@ -456,10 +456,19 @@ class TextGrid(OrderedDict):
                     p += 3
                 else:
                     x0, x1 = [float(grab(s)) for s in data[p:p + 2]]
-                    text = Transcript(grab(data[p + 2]).strip('"'))
+                    str_text, pi = self._grab_text(data, p + 2)
+                    text = Transcript(grab(str_text).strip('"'))
                     tier.append(Interval(text, x0, x1))
-                    p += 4
+                    p += 4 + pi
             self[tier_name] = tier
+
+    @staticmethod
+    def _grab_text(data, index):
+        res, inc = data[index].strip(), 0
+        if res == "text = \"":
+            res += data[index + 1].replace("\n", "")
+            inc = 1
+        return res, inc    
 
     def _parse_short(self, data):
         '''Parse SHORT textgrid files. Not intended to be used directly.'''

--- a/textgrids/__init__.py
+++ b/textgrids/__init__.py
@@ -466,7 +466,7 @@ class TextGrid(OrderedDict):
     def _grab_text(data, index):
         res, inc = data[index].strip(), 0
         if res == "text = \"":
-            res += data[index + 1].replace("\n", "")
+            res += data[index + 1].strip()
             inc = 1
         return res, inc    
 


### PR DESCRIPTION
I had problem reading praat files, like this:
```txt
...
        intervals [2520]:
            xmin = 2088.47546331726 
            xmax = 2090.514000611356 
            text = "
_K" 
        intervals [2521]:
...        
```
Made quick workaround.